### PR TITLE
Build GDAL with netCDF support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,9 +28,9 @@ RUN apt-get update && apt-get install -y \
   wget \
   && rm -rf /var/lib/apt/lists/*
 
-# Install tiledb using 1.7.5 release
+# Install tiledb using 1.7.6 release
 RUN mkdir -p /build_deps && cd /build_deps \
-  && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.5 && cd TileDB \
+  && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.6 && cd TileDB \
   && mkdir -p build && cd build \
   && cmake -DTILEDB_VERBOSE=ON -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local .. \
   && make -j$(nproc) \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
   libpng-dev \
   libfreetype6-dev \  
   libzstd-dev \
+  libnetcdf-dev \
   python3-pip \
   git \
   wget \
@@ -80,7 +81,7 @@ RUN cd /build_deps \
 RUN cd /build_deps \
   && git clone https://github.com/OSGeo/gdal.git && cd gdal/gdal \
   && git checkout 8385b711eef5ed9d034f215e8fa3507c90cd3471 \
-  && ./configure --with-crypto=no --with-curl=no \
+  && ./configure --with-crypto=no --with-curl=no --with-netcdf=yes \
   && make -j$(nproc) \
   && make install
 


### PR DESCRIPTION
Addresses https://github.com/TileDB-Inc/TileDB-Geospatial/issues/11

Change adds netCDF support to GDAL, so it can handle *.nc files.